### PR TITLE
(WiP) Feature implement createQuest() 

### DIFF
--- a/src/api/sim/dtos/PoolDto.ts
+++ b/src/api/sim/dtos/PoolDto.ts
@@ -1,5 +1,5 @@
 import { convertArrayToHashMapByKey } from '../../../utils/logicUtils'
-import { Pool } from '../../../modules'
+import { Pool, PoolType } from '../../../modules'
 import { PoolDataDto } from './PoolDataDto'
 import { PositionDto } from './PositionDto'
 import { PosOwnersDto } from './PosOwnersDto'
@@ -9,7 +9,7 @@ export class PoolDto {
     name: string
     token0: string
     token1: string
-    type: string
+    type: PoolType
     hash: string
     created_at: Date
     pool_data: PoolDataDto

--- a/src/api/sim/dtos/QuestDto.ts
+++ b/src/api/sim/dtos/QuestDto.ts
@@ -1,4 +1,4 @@
-import { Quest, UsdcToken } from '../../../modules'
+import { Quest, QuestKind, UsdcToken } from '../../../modules'
 
 export class QuestDto {
     id: number
@@ -9,6 +9,8 @@ export class QuestDto {
     pools: string[]
     initial_balance_a: number
     initial_balance_b: number
+    kind?: QuestKind
+    content?: string
     created_at: Date
 
     constructor(data, pools) {
@@ -18,6 +20,9 @@ export class QuestDto {
         this.hash = data.hash
         this.is_human = data.is_human
         this.initial_balance_a = data.initial_balance_a
+        this.initial_balance_b = data.initial_balance_b
+        this.kind = data.kind
+        this.content = data.content
         this.initial_balance_b = data.initial_balance_b
         this.pools = pools
         this.created_at = data.created_at
@@ -49,6 +54,8 @@ export class QuestDto {
         token.hash = this.hash
         token.initialBalanceA = this.initial_balance_a
         token.initialBalanceB = this.initial_balance_b
+        token.kind = this.kind
+        token.content = this.content
 
         return token
     }

--- a/src/api/sim/dtos/QuestUploadDto.ts
+++ b/src/api/sim/dtos/QuestUploadDto.ts
@@ -1,3 +1,5 @@
+import { QuestKind } from '../../../modules'
+
 export class QuestUploadDto {
     author_id: number
     name: string
@@ -5,6 +7,8 @@ export class QuestUploadDto {
     is_human: boolean
     initial_balance_a: number
     initial_balance_b: number
+    kind?: QuestKind
+    content?: string
     created_at: Date
 
     constructor(data, investorMappings) {
@@ -15,6 +19,8 @@ export class QuestUploadDto {
         this.is_human = !!data.isHuman
         this.initial_balance_a = data.initialBalanceA || 0
         this.initial_balance_b = data.initialBalanceB || 0
+        this.kind = data.kind
+        this.content = data.content
         this.created_at = data.created_at || new Date()
     }
 

--- a/src/api/web3/Web3API.ts
+++ b/src/api/web3/Web3API.ts
@@ -1,4 +1,5 @@
 import { IAPI } from '../../interfaces'
+import { Quest } from '../../modules'
 
 export interface ConstructorWeb3Config {
     rpcUrl: string
@@ -6,9 +7,15 @@ export interface ConstructorWeb3Config {
 
 export default class Web3API implements IAPI {
     constructor(config: ConstructorWeb3Config) {}
-    createQuest(name: string, description: string): boolean {
+
+    createQuest(
+        snapshotId: number,
+        investorId: number,
+        quest: Partial<Omit<Quest, 'id'>>,
+        followingId?: string
+    ): Promise<Quest> {
         // alternate implementation details
-        return true
+        return Promise.resolve(quest as Quest)
     }
 
     createPool(name: string, description: string): boolean {
@@ -19,5 +26,10 @@ export default class Web3API implements IAPI {
     citeQuest(questId: number, userId: string): boolean {
         // alternate implementation details
         return true
+    }
+
+    fetchQuest(questId: string): Promise<Quest> {
+        // alternate implementation details
+        return Promise.resolve(null as Quest)
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,24 @@
 import SimAPI, { ConstructorSimConfig } from './api/sim/SimAPI'
 import Web3API, { ConstructorWeb3Config } from './api/web3/Web3API'
-import { IAPI } from './interfaces'
+import * as interfaces from './interfaces'
 
 export class SimSdk {
     static init(
         adapter: string = 'sim',
         config: ConstructorSimConfig | ConstructorWeb3Config
-    ): IAPI {
+    ): interfaces.IAPI {
         switch (adapter) {
             case 'sim':
                 return new SimAPI(config as ConstructorSimConfig)
             case 'web3':
                 return new Web3API(config as ConstructorWeb3Config)
+            default:
+                return new SimAPI(config as ConstructorSimConfig)
         }
     }
 }
 
+export type IAPI = interfaces.IAPI
 export * as LogicUtils from './utils/logicUtils'
 export * as MathUtils from './utils/mathUtils'
 export * as Modules from './modules'

--- a/src/interfaces/IAPI.ts
+++ b/src/interfaces/IAPI.ts
@@ -24,7 +24,12 @@ export interface IAPI {
     updatePool?(): void
 
     // Quests API
-    createQuest(name: string, description: string): boolean
+    createQuest(
+        snapshotId: number,
+        investorId: number,
+        quest: Partial<Omit<Quest, 'id'>>,
+        followingId: string | null
+    ): Promise<Quest>
     citeQuest(questId: number, userId: string): boolean
     getQuestsBySnapshot?(snapshotId: number, day?: number): Array<IQuest>
     getQuestDependants?(questId: number): Array<IQuest>
@@ -143,6 +148,8 @@ export interface IAPI {
     fetchTotalsList?(): Promise<ITotalsList>
 
     fetchSnapshotById?(snapshotId: number): Promise<IState>
+
+    fetchQuest(questId: string): Promise<Quest>
 
     auth?()
 }

--- a/src/modules/Pool.ts
+++ b/src/modules/Pool.ts
@@ -17,6 +17,7 @@ interface Position {
     pp?: number
     right?: number
 }
+export declare type PoolType = 'QUEST' | 'VALUE_LINK' | 'BLOCK'
 
 export class Pool {
     id: string
@@ -47,7 +48,7 @@ export class Pool {
     pos = new HashMap<any, any>()
     posOwners = []
 
-    type = 'VALUE_LINK'
+    type: PoolType = 'VALUE_LINK'
     private dryState = {}
 
     /**

--- a/src/modules/Quest.ts
+++ b/src/modules/Quest.ts
@@ -32,6 +32,21 @@ const TEMP_CONFIG = {
         }
     ]
 }
+export declare type QuestKind =
+    | 'INDEX'
+    | 'TITLE'
+    | 'DOI'
+    | 'ABSTRACT'
+    | 'PDF'
+    | 'BODY'
+    | 'IMAGE'
+    | 'EMBED_CODE'
+    | 'USDC'
+    | 'AUTHOR'
+    | 'CATEGORY'
+    | 'LANGUAGE'
+    | 'PUBLICATION_DATE'
+    | 'JOURNAL_NAME'
 
 export class Quest {
     id // make uuid
@@ -41,6 +56,8 @@ export class Quest {
     initialBalanceA = 0
     initialBalanceB = 0
     positions = new HashMap()
+    kind?: QuestKind
+    content?: string
 
     /**
      * @description Instantiates new Token with name


### PR DESCRIPTION
[Jira AD-101](https://agora-labs.atlassian.net/browse/AD-101)
- extended quest table with new fields **kind** and **content** (_content gonna be merged with name field in future_)
- saving new quest in SimDB within certain snapshotId and investorId relation provided (_default hardcoded in quests for now_)
- create Pool (again if **followingId** value is provided)
- skiping Balance record creation for now

**TBD**:
* USDC-pool creation within each quest creation
* define default set of values needed for cross-pool and usdc-pool
* define default USDC-Token quest for each snapshot (singleton in simulator's snapshot)